### PR TITLE
Fix: Correct 'mss' import in screen capture for VideoIn processor

### DIFF
--- a/genai_processors/core/video.py
+++ b/genai_processors/core/video.py
@@ -53,7 +53,7 @@ def _get_single_camera_frame(
 def _get_single_screen_frame(substream_name: str) -> ProcessorPart:
   """Get a single frame from the screen."""
   try:
-    from mss import mss  # pytype: disable=import-error # pylint: disable=g-import-not-at-top
+    import mss
   except ImportError as e:
     raise ImportError("Please install mss package using 'pip install mss'") from e
   sct = mss.mss()


### PR DESCRIPTION
## Summary
Fixes a critical bug in the `VideoIn` processor related to screen capture mode.

## What Changed
- Corrected the import of the `mss` module from `from mss import mss` to `import mss`.
- This avoids shadowing the module name and fixes the error:
  `'function' object has no attribute 'mss'`.

## Why
The original import incorrectly shadows the module, causing a runtime `AttributeError`.

## Testing
✅ Verified locally for both:
- `video_mode=VideoMode.SCREEN`
- `video_mode=VideoMode.CAMERA`
