### PR TITLE
Fix minor typos

### DIFF
--- a/examples/realtime_simple_cli.py
+++ b/examples/realtime_simple_cli.py
@@ -26,8 +26,8 @@ To install the dependencies for this script, run:
 pip install --upgrade pyaudio genai-processors google-genai termcolor
 ```
 
-Before running this script, ensure the `GOOGLE_API_KEY` environment
-variable is set to the api-key you obtained from Google AI Studio.
+Before running this script, ensure the `GOOGLE_API_KEY` and `GOOGLE_PROJECT_ID` environment
+variable are set to the api-key you obtained from Google AI Studio.
 
 Important: **Use headphones**. This script uses the system default audio
 input and output, which often won't include echo cancellation. So to prevent

--- a/examples/realtime_simple_cli.py
+++ b/examples/realtime_simple_cli.py
@@ -26,8 +26,8 @@ To install the dependencies for this script, run:
 pip install --upgrade pyaudio genai-processors google-genai termcolor
 ```
 
-Before running this script, ensure the `GOOGLE_API_KEY` and `GOOGLE_PROJECT_ID` environment
-variable are set to the api-key you obtained from Google AI Studio.
+Before running this script, ensure the `GOOGLE_API_KEY` and `GOOGLE_PROJECT_ID`
+environment variables are set to the api-key you obtained from Google AI Studio.
 
 Important: **Use headphones**. This script uses the system default audio
 input and output, which often won't include echo cancellation. So to prevent

--- a/examples/realtime_simple_cli.py
+++ b/examples/realtime_simple_cli.py
@@ -74,7 +74,7 @@ INSTRUCTION_PARTS = [
     ' explain interesting facts related to what you see and hear, predict what'
     ' could happen, judge some actions or reactions, etc. Respond to the'
     ' user in a few sentences maximum: keep it short and engaging. Avoid'
-    ' long monologues. You can use Google search to add extra inforamtion to'
+    ' long monologues. You can use Google search to add extra information to'
     ' the user questions or to come up with interesting news or facts.'
 ]
 

--- a/examples/research/README.md
+++ b/examples/research/README.md
@@ -56,7 +56,7 @@ The Research Agent follows a structured pipeline:
     *   Each researched `Topic` part is transformed into a human-readable
         Markdown string, summarizing the topic, its relation to the original
         query, and the research findings. The verbalization done with a
-        [Jinja2 template processor](https://github/google-gemini/genai-processors/blob/main/core/jinja_template.py).
+        [Jinja2 template processor](https://github.com/google-gemini/genai-processors/blob/main/core/jinja_template.py).
 5.  **Synthesis (within `ResearchAgent`)**:
     *   All verbalized research texts are collected.
     *   A final `GenaiModel` is prompted (using `prompts.SYNTHESIS_PREAMBLE`) to

--- a/examples/trip_request_cli_ollama.py
+++ b/examples/trip_request_cli_ollama.py
@@ -32,7 +32,7 @@ Before running this script, ensure the `GOOGLE_API_KEY` environment
 variable is set to the api-key you obtained from Google AI Studio.
 
 Usage:
-  python3 trip_request_cli.py
+  python3 trip_request_cli_ollama.py
 """
 import asyncio
 from collections.abc import AsyncIterable

--- a/genai_processors/examples/__init__.py
+++ b/genai_processors/examples/__init__.py
@@ -14,9 +14,9 @@
 # ==============================================================================
 """Examples are in the root of the git repository, see the parent folder.
 
-To make examples easily discoverable we need them to be in the parent foler. But
+To make examples easily discoverable we need them to be in the parent folder. But
 when doing local development with `PYTHONPATH=.`Python will look for them here.
-This magic tell Python where the examples packages are really located.
+This magic tells Python where the examples packages are really located.
 """
 
 import importlib

--- a/genai_processors/examples/__init__.py
+++ b/genai_processors/examples/__init__.py
@@ -14,9 +14,9 @@
 # ==============================================================================
 """Examples are in the root of the git repository, see the parent folder.
 
-To make examples easily discoverable we need them to be in the parent folder. But
-when doing local development with `PYTHONPATH=.`Python will look for them here.
-This magic tells Python where the examples packages are really located.
+To make examples easily discoverable we need them to be in the parent folder.
+But when doing local development with `PYTHONPATH=.`Python will look for them
+here. This magic tells Python where the examples packages are really located.
 """
 
 import importlib


### PR DESCRIPTION
This pull request several minor typos and documentation errors across the project's examples.

*   Corrects the usage command in the `trip_request_cli_ollama.py` docstring.
*   Fixes a typo ("inforamtion") in the `realtime_simple_cli.py` prompt.
*   Adds the required `GOOGLE_PROJECT_ID` to the setup instructions in `realtime_simple_cli.py`.
*   Fixes a broken link in the research example's README file.
*   Corrects minor grammatical errors in the `genai_processors/examples/__init__.py` docstring.