### PR TITLE
fix: Resolve #21 link in contrib README to point correctly to CONTRIB

### DIFF
--- a/genai_processors/contrib/README.md
+++ b/genai_processors/contrib/README.md
@@ -1,3 +1,3 @@
 # Processors contributed by the community
 
-We welcome contributions of new Processors that can be shared with the community. Please see [https://github.com/google-gemini/genai-processors/blob/main/CONTRIBUTING.md](CONTRIBUTING.md) for the details.
+We welcome contributions of new Processors that can be shared with the community. Please see [CONTRIBUTING.md](../../CONTRIBUTING.md) for the details.


### PR DESCRIPTION
This pull request includes a minor update to the `README.md` file in the `genai_processors/contrib` directory. The change fixes a relative link to the `CONTRIBUTING.md` file, ensuring it points to the correct location.