### PR TITLE
chore: Add pydantic repo link and description to contrib

### DIFF
--- a/genai_processors/contrib/README.md
+++ b/genai_processors/contrib/README.md
@@ -6,5 +6,5 @@ We welcome contributions of new Processors that can be shared with the community
 
 ## List of contributed processors
 
-* [Processor name](processor.py): short description.
-* [genai-processors-pydantic](https://github.com/mbeacom/genai-processors-pydantic/): The PydanticValidator is a PartProcessor that validates the JSON content of a ProcessorPart against a specified Pydantic model.
+ * [mbeacom/genai-processors-pydantic](https://github.com/mbeacom/genai-processors-pydantic/): The PydanticValidator is a PartProcessor that validates the JSON content of a ProcessorPart against a specified Pydantic model.
+ <!--- * [Processor name](processor.py): short description. -->

--- a/genai_processors/contrib/README.md
+++ b/genai_processors/contrib/README.md
@@ -6,4 +6,5 @@ We welcome contributions of new Processors that can be shared with the community
 
 ## List of contributed processors
 
- * [Processor name](processor.py): short description.
+* [Processor name](processor.py): short description.
+* [genai-processors-pydantic](https://github.com/mbeacom/genai-processors-pydantic/): The PydanticValidator is a PartProcessor that validates the JSON content of a ProcessorPart against a specified Pydantic model.


### PR DESCRIPTION
This pull request adds a new contributed processor to the list in the `genai_processors/contrib/README.md` file as discussed in: https://github.com/google-gemini/genai-processors/pull/20#issuecomment-3068612166. The processor is named `genai-processors-pydantic` and provides functionality for validating JSON content against a Pydantic model as described in: https://github.com/mbeacom/genai-processors-pydantic // https://pypi.org/project/genai-processors-pydantic/