### PR TITLE
docs: Add third-party UrlFetchProcessor to the list of contrib processors

### DIFF
--- a/genai_processors/contrib/README.md
+++ b/genai_processors/contrib/README.md
@@ -7,4 +7,5 @@ We welcome contributions of new Processors that can be shared with the community
 ## List of contributed processors
 
  * [mbeacom/genai-processors-pydantic](https://github.com/mbeacom/genai-processors-pydantic/): The PydanticValidator is a PartProcessor that validates the JSON content of a ProcessorPart against a specified Pydantic model.
+ * [mbeacom/genai-processors-url-fetch](https://github.com/mbeacom/genai-processors-url-fetch/): The UrlFetchProcessor detects URLs in text parts, fetches their content concurrently, and yields new ProcessorParts with extracted content (HTML, text, or markdown).
  <!--- * [Processor name](processor.py): short description. -->


### PR DESCRIPTION
This pull request adds a new contributed processor to the list in the `README.md` file for `genai_processors/contrib`.

* Documentation update:
  * Added the `UrlFetchProcessor` to the list of contributed processors in `genai_processors/contrib/README.md`. This processor detects URLs in text parts, fetches their content concurrently, and creates new `ProcessorParts` with the extracted content (HTML, text, or markdown).
  
I'm happy to update this or adjust my implementation now that Cache part is available.