### PR TITLE
fix: resolve F821 undefined name error in empty processor test

### DIFF
--- a/genai_processors/tests/processor_test.py
+++ b/genai_processors/tests/processor_test.py
@@ -1429,7 +1429,6 @@ class CachedPartProcessorTest(
     async def empty_processor(
         part: content_api.ProcessorPart,
     ) -> AsyncIterable[content_api.ProcessorPart]:
-      del part
       call_tracker()
       # We need to simulate the case where no parts are yielded,
       # while satisfying the type checker.


### PR DESCRIPTION
This change is intended to resolve the failing test introduced by: https://github.com/google-gemini/genai-processors/commit/e87958596567712c4d78aa04ede0a52f4e83e49b  I removed the unnecessary del part statement. The parameter is unused but harmless, and is required for the if False: yield part pattern that satisfies the type checker's generator function requirement.