### PR TITLE
Adds latency probers and a throttler.

### DIFF
--- a/genai_processors/dev/README.md
+++ b/genai_processors/dev/README.md
@@ -1,10 +1,87 @@
 # Development Tools for Processors
 
+## Stream latency monitoring
+
+`latency.py` provides a lightweight solution for diagnosing and managing performance issues in real-time streaming pipelines (e.g., video feeds, live audio). The telemetry hooks rely on `time.monotonic()` and lightweight dictionary updates. They run at native Python speeds without blocking your async stream.
+
+Measuring latency is done via probing: we inject non-intrusive tracking parts into your stream to map out precise end-to-end processing times and frame rates (FPS) at every step.
+
+To trace a pipeline:
+
+1. Place a Prober at the very start of your pipeline or after any processor generating the parts you want to track latency for.
+2. Insert ProbeCheckpoint milestones after any processing blocks you want to measure latency of.
+3. Use ProbeLog at the end to print the metrics.
+
+By default, all parts on the default substream are considered. Status or debug
+parts are ignored.
+
+A prober is a processor so it can easily be combined with any existing processor chain or any existing pipeline.
+
+For example:
+
+```python
+from genai_processors.dev import latency
+    
+model = (
+    # Check telemetry every 1s
+    latency.Prober(tag="Source", interval_seconds=1.0)
+    + extract_img_from_video_processor
+    + latency.ProbeCheckpoint(tag="Extract")
+    + crop_img_processor
+    + latency.ProbeCheckpoint(tag="Crop")
+    + latency.ProbeLog()  # Outputs telemetry to console
+)
+# When computing the output_stream, the probers will collect 
+# statistics between the check points
+output_stream = model(input_stream)
+```
+
+Example Log Output (collected from the default substream):
+
+```shell
+INFO:absl:Latency Trace[default]: Source (+0.0ms, 30.0fps) -> Extract (+45.2ms, 22.5fps) -> Crop (+20.3ms, 22.5fps) | Total: 75.4ms
+```
+
+## Handling Latency Issues (The Throttling Trick)
+
+If a downstream consumer or model slows down, incoming data will back up, causing memory spikes or severe lag.
+
+The Throttler processor plays the role of a safety valve. It uses a small internal buffer (max_size) to drop older, stale data (like old video frames) so your pipeline stays strictly locked to real-time speeds.
+
+While it drops regular data to clear congestion, it never drops probing/telemetry data. Telemetry tokens are automatically prioritized and pushed through, ensuring your performance graphs and logs remain completely unbroken even during heavy traffic spikes.
+
+Drop the Throttler right before any known bottleneck or slow consumer in your processor chain.
+
+```python
+from genai_processors.dev import latency
+
+model = (
+    latency.Prober(tag="Source", interval_seconds=1.0)
+    + extract_img_from_video_processor
+    + latency.ProbeCheckpoint(tag="Extract")
+    + latency.Throttler("Before Crop")
+    + crop_img_processor
+    + latency.ProbeCheckpoint(tag="Crop")
+    + latency.ProbeLog()
+)
+
+# If the input_stream generates content faster than 
+# what the pipeline can process, the throttler "Before Crop"
+# will drop frames.
+output_stream = model(input_stream)
+ ```
+
+Example Log Output:
+
+```shell
+WARNING:absl:Throttler [Audio] queue full, dropping oldest non-prober part: image/jpeg
+```
+
 ## Processor Trace
 
 Processor traces allow you to record the inputs, outputs, and internal steps of
 a processor during its execution. This is useful for debugging, analysis, and
-understanding processor behavior.
+understanding processor behavior beyond latency.
 
 A trace is a timeline of events, where each event represents an input part, an
 output part, or a call to a sub-processor. Events are time stamped and ordered
@@ -42,7 +119,7 @@ The default implementation of tracing is done with `trace_file.SyncFileTrace`.
 When a processor is called within a `SyncFileTrace`, it records its execution
 and saves it into two files under `trace_dir` provided to the trace scope:
 
--   `{processor_name}_{trace_id}.json` containing a json dictionary that can be
+- `{processor_name}_{trace_id}.json` containing a json dictionary that can be
 loaded for further programmatic analysis using `SyncFileTrace.load`:
 
     ```python
@@ -59,7 +136,7 @@ loaded for further programmatic analysis using `SyncFileTrace.load`:
             )
     ```
 
--   `{processor_name}_{trace_id}.html` containing an HTML representation of the
+- `{processor_name}_{trace_id}.html` containing an HTML representation of the
 trace that can easily be viewed on a web browser. This is the same content as
 the json dictionary.
 
@@ -72,14 +149,14 @@ can then be used in place of `SyncFileTrace`.
 
 You must implement the following methods:
 
-*   `async def add_input(self, part: content_api.ProcessorPart) -> None`:
+- `async def add_input(self, part: content_api.ProcessorPart) -> None`:
 Handles input parts received by the processor.
-*   `async def add_output(self, part: content_api.ProcessorPart) -> None`:
+- `async def add_output(self, part: content_api.ProcessorPart) -> None`:
 Handles output parts produced by the processor.
-*   `async def add_sub_trace(self) -> Trace`:
+- `async def add_sub_trace(self) -> Trace`:
 Handles the start of a nested processor call. The returned `trace` should be an
 instance of your custom trace implementation.
-*   `async def _finalize(self) -> None:`: Called when the trace context is
+- `async def _finalize(self) -> None:`: Called when the trace context is
 exited. Use this to perform final actions like flushing buffers, closing
 connections, or writing data to disk.
 

--- a/genai_processors/dev/latency.py
+++ b/genai_processors/dev/latency.py
@@ -1,7 +1,8 @@
 """Latency monitoring and stream throttling processors."""
 
-from pydantic import alias_generators
 import asyncio
+import collections
+import numpy as np
 import time
 
 from absl import logging
@@ -141,20 +142,25 @@ class ProbeCheckpoint(processor.Processor):
                     )
                     delta = now - prev_time
 
-                    # Calculate FPS since last probed part
+                    # Calculate FPS: count of non-prober parts since the
+                    # last prober part, divided by elapsed wall time.
                     duration = now - last_probed_time
                     fps = part_counter / duration if duration > 0 else 0
 
                     markers.append((self.tag, now, delta, fps))
 
-                    # Reset counters
+                    # Reset counters. Do NOT increment part_counter here:
+                    # the prober part itself is not counted as a frame.
                     last_probed_time = now
                     part_counter = 0
-                part_counter += 1
+                else:
+                    # Only non-prober parts in the target substream count
+                    # toward the FPS of the next checkpoint.
+                    part_counter += 1
             yield part
 
 
-class ProbeLog(processor.PartProcessor):
+class ProbeLog(processor.Processor):
     """Logs the full probe sequence latency results and yields an extra part.
 
     The extra part contains the same prober metadata as the input part and
@@ -187,24 +193,41 @@ class ProbeLog(processor.PartProcessor):
         """
         self._substream_name = substream_name
         self._part_formatter = part_formatter
+        self._part_formatter = part_formatter
         self._latency_substream = latency_substream
 
     async def call(
-        self, part: content_api.ProcessorPart
+        self, content: AsyncIterable[content_api.ProcessorPart]
     ) -> AsyncIterable[content_api.ProcessorPartTypes]:
-        yield part
-        prober = part.metadata.get('prober')
-        if prober:
-            part_repr = (
-                self._part_formatter(part).strip() if self._part_formatter else None
-            )
-            Prober.log_arrival(part, part_repr)
-            if self._latency_substream is not None:
-                yield content_api.ProcessorPart(
-                    '',
-                    metadata={'prober': prober},
-                    substream_name=self._latency_substream,
+        latencies_ms = {}
+        async for part in content:
+            yield part
+            prober = part.metadata.get('prober')
+            if prober:
+                part_repr = (
+                    self._part_formatter(part).strip() if self._part_formatter else None
                 )
+                for m in prober.get('markers', []):
+                    tag, delta, fps = m[0], m[2], m[3]
+                    if tag not in latencies_ms:
+                        latencies_ms[tag] = []
+                    latencies_ms[tag].append((delta, fps))
+                Prober.log_arrival(part, part_repr)
+                if self._latency_substream is not None:
+                    yield content_api.ProcessorPart(
+                        '',
+                        metadata={'prober': prober},
+                        substream_name=self._latency_substream,
+                    )
+        for tag, latencies in latencies_ms.items():
+            logging.info(
+                "Latency stats for %s: %.1f +/- %.1f ms (%.1f +/- %.1f FPS)",
+                tag,
+                np.mean([l[0] for l in latencies]) * 1000,
+                np.std([l[0] for l in latencies]) * 1000,
+                np.mean([l[1] for l in latencies]),
+                np.std([l[1] for l in latencies]),
+            )
 
 
 class Throttler(processor.Processor):
@@ -233,65 +256,69 @@ class Throttler(processor.Processor):
     async def call(
         self, content: processor.ProcessorStream
     ) -> AsyncIterable[content_api.ProcessorPartTypes]:
-        # input_queue stores parts until max_size is reached.
-        input_queue = asyncio.Queue(maxsize=self.max_size)
-        # output_queue is used to hand off parts to the consumer.
+        # output_queue is the single hand-off point between the producer
+        # and the consumer (maxsize=1 provides natural backpressure).
         output_queue = asyncio.Queue(maxsize=1)
-
-        async def bridge():
-            """Bridges input_queue to output_queue."""
-            while (part := await input_queue.get()) is not None:
-                await output_queue.put(part)
-            await output_queue.put(None)
+        # drop_buffer holds at most max_size parts pending dispatch.
+        # When full, the oldest part is evicted (dropped or promoted).
+        drop_buffer: collections.deque[content_api.ProcessorPart] = collections.deque(
+            maxlen=self.max_size
+        )
 
         async def producer():
+            """Buffers incoming parts and feeds output_queue directly.
+
+            Uses drop_buffer to absorb bursts. When the buffer is full
+            and the consumer is slow, the oldest part is evicted. Prober
+            parts are promoted to the front of output_queue so that
+            latency measurements survive congestion.
+            """
             last_logged = time.monotonic()
             log_count = 0
             async for part in content:
-                if input_queue.full():
-                    oldest_part = input_queue.get_nowait()
+                if len(drop_buffer) == self.max_size:
+                    oldest_part = drop_buffer.popleft()
                     prober = oldest_part.metadata.get('prober')
                     if prober:
-                        # We put the prober in the front line if
-                        # the output queue does not contain already
-                        # a prober, otherwise, we drop it. This way,
-                        # we guarantee that we return at least one part
-                        # with prober info, while not blocking the
-                        # pipeline.
-                        output_part = output_queue.get_nowait()
-                        if output_part.metadata.get('prober'):
-                            output_queue.put_nowait(output_part)
+                        # Promote the evicted prober: place it into
+                        # output_queue, displacing a non-prober if
+                        # necessary so we never block the pipeline.
+                        if not output_queue.empty():
+                            output_part = output_queue.get_nowait()
+                            if output_part.metadata.get('prober'):
+                                output_queue.put_nowait(output_part)
+                            else:
+                                output_queue.put_nowait(oldest_part)
                         else:
                             output_queue.put_nowait(oldest_part)
                     else:
-                        part_type = (
-                            oldest_part.text
-                            if content_api.is_text(oldest_part.mimetype)
-                            and oldest_part.text
-                            else oldest_part.mimetype
-                        )
                         now = time.monotonic()
                         log_count += 1
                         if now - last_logged >= self.log_interval_sec:
                             logging.warning(
                                 'Throttler [%s] queue full, dropped %d '
                                 'non-prober parts since last log message %.2f '
-                                'sec ago, oldest non-prober part: %s',
+                                'sec ago',
                                 self.tag,
                                 log_count,
                                 now - last_logged,
-                                part_type,
                             )
                             log_count = 0
                             last_logged = now
-                input_queue.put_nowait(part)
-            await input_queue.put(None)
+                drop_buffer.append(part)
+                # Flush buffered parts to output_queue as fast as the
+                # consumer allows (single async hop, no bridge task).
+                while drop_buffer and not output_queue.full():
+                    output_queue.put_nowait(drop_buffer.popleft())
 
-        bridge_task = processor.create_task(bridge())
+            # Drain any remaining buffered parts, then signal EOS.
+            for remaining in drop_buffer:
+                await output_queue.put(remaining)
+            await output_queue.put(None)
+
         producer_task = processor.create_task(producer())
         try:
             async for part in streams.dequeue(output_queue):
                 yield part
         finally:
             producer_task.cancel()
-            bridge_task.cancel()

--- a/genai_processors/dev/latency.py
+++ b/genai_processors/dev/latency.py
@@ -1,5 +1,6 @@
 """Latency monitoring and stream throttling processors."""
 
+from pydantic import alias_generators
 import asyncio
 import time
 
@@ -14,11 +15,18 @@ from genai_processors import streams
 class Prober(processor.Processor):
     """Initiates a probe sequence every `interval_seconds`.
 
-    Adds a `prober` dictionary to the part's metadata containing the
-    initiation time and an empty list of probe points.
+    Every `interval_seconds` marks a part for latency probing.
 
-    A probe point is a tuple of (tag, timestamp, delta, fps) and
-    is typically added by a ProbeCheckpoint processor (defined below).
+    Adds a `prober` dictionary to the part's metadata containing the
+    initiation time and an empty list of probe points. These probe points
+    will later be populated by ProbeCheckpoint processor when the part
+    reaches it.
+
+    A probe point is a tuple of (tag, timestamp, delta, fps) tuples where:
+      tag: Name of the tuple.
+      timestamp: Time when the part reached the checkpoint.
+      delta: Time elapsed since the previous marker.
+      fps: Frames per second since the previous marker.
     """
 
     def __init__(
@@ -51,9 +59,9 @@ class Prober(processor.Processor):
                 fps = part_counter / duration if duration > 0 else 0
 
                 # Initialize the probe structure
-                part.metadata["prober"] = {
-                    "start_time": now,
-                    "markers": [
+                part.metadata['prober'] = {
+                    'start_time': now,
+                    'markers': [
                         (self.tag, now, 0, fps)
                     ],  # Start marker with its own FPS
                 }
@@ -64,12 +72,14 @@ class Prober(processor.Processor):
             yield part
 
     @staticmethod
-    def log_arrival(part: content_api.ProcessorPart):
+    def log_arrival(
+        part: content_api.ProcessorPart, part_repr: str | None = None
+    ) -> None:
         """Logs the full probe sequence latency results."""
-        prober = part.metadata.get("prober")
+        prober = part.metadata.get('prober')
         if prober:
-            start_time = prober.get("start_time", 0)
-            markers = prober.get("markers", [])
+            start_time = prober.get('start_time', 0)
+            markers = prober.get('markers', [])
 
             if not markers:
                 return
@@ -79,18 +89,20 @@ class Prober(processor.Processor):
             for m in markers:
                 tag, ts, delta = m[0], m[1], m[2]
                 fps = m[3] if len(m) > 3 else 0
-                trace_parts.append(f"{tag} (+{delta*1000:.1f}ms, {fps:.1f}fps)")
+                trace_parts.append(f'{tag} (+{delta*1000:.1f}ms, {fps:.1f}fps)')
 
-            trace = " -> ".join(trace_parts)
+            trace = ' -> '.join(trace_parts)
             total_ms = (time.monotonic() - start_time) * 1000
-            substream_name = part.substream_name or "default"
+            substream_name = part.substream_name or 'default'
 
             logging.info(
-                "Latency Trace [%s]: %s | Total: %.1fms",
+                'Latency Trace [%s]: %s | Total: %.1fms',
                 substream_name,
                 trace,
                 total_ms,
             )
+            if part_repr:
+                logging.info('Latency Trace [part repr]: %s', part_repr)
 
 
 class ProbeCheckpoint(processor.Processor):
@@ -99,7 +111,7 @@ class ProbeCheckpoint(processor.Processor):
     Appends timing information to the `prober` metadata dictionary.
     """
 
-    def __init__(self, tag: str, substream_name: str = ""):
+    def __init__(self, tag: str, substream_name: str = ''):
         """Initializes the probe checkpoint.
 
         Args:
@@ -118,14 +130,14 @@ class ProbeCheckpoint(processor.Processor):
         last_probed_time = time.monotonic()
         async for part in content:
             if part.substream_name == self.substream_name:
-                prober = part.metadata.get("prober")
+                prober = part.metadata.get('prober')
                 if prober:
                     now = time.monotonic()
-                    markers = prober.get("markers", [])
+                    markers = prober.get('markers', [])
 
                     # Calculate delta from previous marker or start_time
                     prev_time = (
-                        markers[-1][1] if markers else prober.get("start_time", now)
+                        markers[-1][1] if markers else prober.get('start_time', now)
                     )
                     delta = now - prev_time
 
@@ -149,64 +161,74 @@ class ProbeLog(processor.PartProcessor):
     is sent to a substream (default to: "latency"). This allows one to filter
     only the latency parts, for example in order to save the full probe trace
     for later analysis.
+
+    If the extra part is not needed, set `latency_substream` to `None`.
     """
 
     def __init__(
         self,
-        substream_name: str = "",
-        msg: Callable[[content_api.ProcessorPart], str] = None,
-        latency_substream: str = "latency",
+        substream_name: str = '',
+        part_formatter: Callable[[content_api.ProcessorPart], str] | None = None,
+        latency_substream: str | None = 'latency',
     ):
         """Initializes the probe log.
 
         Args:
             substream_name: Parts will be output on this substream.
               Note that parts from all substreams are considered.
-            msg: A callback that takes a part and returns its string
-              representation.
+            part_formatter: A function that returns the string
+              representation of a part. Default is `None`: no representation
+              is shown during latency trace. If set, the log will include
+              the part representation after the latency trace. This can be
+              useful for debugging.
             latency_substream: The name of the substream to emit the latency part on.
-              Default is "latency".
+              Default is "latency". When set to `None`, no latency part is emitted.
+
         """
         self._substream_name = substream_name
-        self._msg = msg
+        self._part_formatter = part_formatter
         self._latency_substream = latency_substream
 
     async def call(
         self, part: content_api.ProcessorPart
     ) -> AsyncIterable[content_api.ProcessorPartTypes]:
         yield part
-        prober = part.metadata.get("prober")
+        prober = part.metadata.get('prober')
         if prober:
-            Prober.log_arrival(part)
-            if self._msg:
-                msg_str = self._msg(part).strip()
-                if msg_str:
-                    logging.info("Latency msg: %s", msg_str)
-            yield content_api.ProcessorPart(
-                "",
-                metadata={"prober": prober},
-                substream_name=self._latency_substream,
+            part_repr = (
+                self._part_formatter(part).strip() if self._part_formatter else None
             )
+            Prober.log_arrival(part, part_repr)
+            if self._latency_substream is not None:
+                yield content_api.ProcessorPart(
+                    '',
+                    metadata={'prober': prober},
+                    substream_name=self._latency_substream,
+                )
 
 
 class Throttler(processor.Processor):
     """Throttles the stream by dropping parts if the consumer is too slow.
 
     This processor maintains an internal buffer and drops the oldest non-prober
-    part when capacity is reached. Parts containing prober information are
-    never dropped; instead, they are prioritized and pushed directly to the
-    output when congestion occurs, ensuring complete latency traces.
+    part when capacity is reached.
+
+    The logic guarantees that at least one part with prober information is
+    returned even if the buffer is full. This ensures we get latency information
+    even when the pipeline is congested.
     """
 
-    def __init__(self, tag: str, max_size: int = 2):
+    def __init__(self, tag: str, max_size: int = 2, log_interval_sec: float = 5.0):
         """Initializes the throttler.
 
         Args:
             tag: A label for this throttler used in log messages.
             max_size: Maximum number of parts to buffer before dropping.
+            log_interval_sec: Minimum time between log messages. Default is 5.0.
         """
         self.tag = tag
         self.max_size = max_size
+        self.log_interval_sec = log_interval_sec
 
     async def call(
         self, content: processor.ProcessorStream
@@ -223,13 +245,24 @@ class Throttler(processor.Processor):
             await output_queue.put(None)
 
         async def producer():
+            last_logged = time.monotonic()
+            log_count = 0
             async for part in content:
                 if input_queue.full():
                     oldest_part = input_queue.get_nowait()
-                    prober = oldest_part.metadata.get("prober")
+                    prober = oldest_part.metadata.get('prober')
                     if prober:
-                        # We block on probers, since we want to see the full trace.
-                        await output_queue.put(oldest_part)
+                        # We put the prober in the front line if
+                        # the output queue does not contain already
+                        # a prober, otherwise, we drop it. This way,
+                        # we guarantee that we return at least one part
+                        # with prober info, while not blocking the
+                        # pipeline.
+                        output_part = output_queue.get_nowait()
+                        if output_part.metadata.get('prober'):
+                            output_queue.put_nowait(output_part)
+                        else:
+                            output_queue.put_nowait(oldest_part)
                     else:
                         part_type = (
                             oldest_part.text
@@ -237,11 +270,20 @@ class Throttler(processor.Processor):
                             and oldest_part.text
                             else oldest_part.mimetype
                         )
-                        logging.warning(
-                            "Throttler [%s] queue full, dropping oldest non-prober part: %s",
-                            self.tag,
-                            part_type,
-                        )
+                        now = time.monotonic()
+                        log_count += 1
+                        if now - last_logged >= self.log_interval_sec:
+                            logging.warning(
+                                'Throttler [%s] queue full, dropped %d '
+                                'non-prober parts since last log message %.2f '
+                                'sec ago, oldest non-prober part: %s',
+                                self.tag,
+                                log_count,
+                                now - last_logged,
+                                part_type,
+                            )
+                            log_count = 0
+                            last_logged = now
                 input_queue.put_nowait(part)
             await input_queue.put(None)
 

--- a/genai_processors/dev/latency.py
+++ b/genai_processors/dev/latency.py
@@ -1,0 +1,257 @@
+"""Latency monitoring and stream throttling processors."""
+
+import asyncio
+import time
+
+from absl import logging
+from collections.abc import AsyncIterable
+from collections.abc import Callable
+from genai_processors import content_api
+from genai_processors import processor
+from genai_processors import streams
+
+
+class Prober(processor.Processor):
+    """Initiates a probe sequence every `interval_seconds`.
+
+    Adds a `prober` dictionary to the part's metadata containing the
+    initiation time and an empty list of probe points.
+
+    A probe point is a tuple of (tag, timestamp, delta, fps) and
+    is typically added by a ProbeCheckpoint processor (defined below).
+    """
+
+    def __init__(
+        self,
+        tag: str,
+        interval_seconds: float = 1.0,
+    ):
+        """Initializes the prober.
+
+        Args:
+            tag: The label for the initiation point.
+            interval_seconds: Frequency of probes in seconds.
+        """
+        self.tag = tag
+        self.interval_seconds = interval_seconds
+
+    async def call(
+        self, content: processor.ProcessorStream
+    ) -> AsyncIterable[content_api.ProcessorPartTypes]:
+        last_probe_time = time.monotonic()
+        part_counter = 0
+
+        async for part in content:
+            now = time.monotonic()
+            if now - last_probe_time >= self.interval_seconds:
+                # We count the current part into the next interval.
+                # This can reduce a bit the FPS for the first interval
+                # but should even out over time.
+                duration = now - last_probe_time
+                fps = part_counter / duration if duration > 0 else 0
+
+                # Initialize the probe structure
+                part.metadata["prober"] = {
+                    "start_time": now,
+                    "markers": [
+                        (self.tag, now, 0, fps)
+                    ],  # Start marker with its own FPS
+                }
+                last_probe_time = now
+                part_counter = 0
+            part_counter += 1
+
+            yield part
+
+    @staticmethod
+    def log_arrival(part: content_api.ProcessorPart):
+        """Logs the full probe sequence latency results."""
+        prober = part.metadata.get("prober")
+        if prober:
+            start_time = prober.get("start_time", 0)
+            markers = prober.get("markers", [])
+
+            if not markers:
+                return
+
+            # Build a trace string: Stage1 (+10ms, 50fps) -> Stage2 ...
+            trace_parts = []
+            for m in markers:
+                tag, ts, delta = m[0], m[1], m[2]
+                fps = m[3] if len(m) > 3 else 0
+                trace_parts.append(f"{tag} (+{delta*1000:.1f}ms, {fps:.1f}fps)")
+
+            trace = " -> ".join(trace_parts)
+            total_ms = (time.monotonic() - start_time) * 1000
+            substream_name = part.substream_name or "default"
+
+            logging.info(
+                "Latency Trace [%s]: %s | Total: %.1fms",
+                substream_name,
+                trace,
+                total_ms,
+            )
+
+
+class ProbeCheckpoint(processor.Processor):
+    """Records a latency checkpoint for parts being probed.
+
+    Appends timing information to the `prober` metadata dictionary.
+    """
+
+    def __init__(self, tag: str, substream_name: str = ""):
+        """Initializes the probe checkpoint.
+
+        Args:
+            tag: Name of the checkpoint/stage.
+            substream_name: Only parts in this substream are considered
+                to compute the metrics and to add the next marker to
+                the probe info. Default substream is used if empty string.
+        """
+        self.tag = tag
+        self.substream_name = substream_name
+
+    async def call(
+        self, content: processor.ProcessorStream
+    ) -> AsyncIterable[content_api.ProcessorPartTypes]:
+        part_counter = 0
+        last_probed_time = time.monotonic()
+        async for part in content:
+            if part.substream_name == self.substream_name:
+                prober = part.metadata.get("prober")
+                if prober:
+                    now = time.monotonic()
+                    markers = prober.get("markers", [])
+
+                    # Calculate delta from previous marker or start_time
+                    prev_time = (
+                        markers[-1][1] if markers else prober.get("start_time", now)
+                    )
+                    delta = now - prev_time
+
+                    # Calculate FPS since last probed part
+                    duration = now - last_probed_time
+                    fps = part_counter / duration if duration > 0 else 0
+
+                    markers.append((self.tag, now, delta, fps))
+
+                    # Reset counters
+                    last_probed_time = now
+                    part_counter = 0
+                part_counter += 1
+            yield part
+
+
+class ProbeLog(processor.PartProcessor):
+    """Logs the full probe sequence latency results and yields an extra part.
+
+    The extra part contains the same prober metadata as the input part and
+    is sent to a substream (default to: "latency"). This allows one to filter
+    only the latency parts, for example in order to save the full probe trace
+    for later analysis.
+    """
+
+    def __init__(
+        self,
+        substream_name: str = "",
+        msg: Callable[[content_api.ProcessorPart], str] = None,
+        latency_substream: str = "latency",
+    ):
+        """Initializes the probe log.
+
+        Args:
+            substream_name: Parts will be output on this substream.
+              Note that parts from all substreams are considered.
+            msg: A callback that takes a part and returns its string
+              representation.
+            latency_substream: The name of the substream to emit the latency part on.
+              Default is "latency".
+        """
+        self._substream_name = substream_name
+        self._msg = msg
+        self._latency_substream = latency_substream
+
+    async def call(
+        self, part: content_api.ProcessorPart
+    ) -> AsyncIterable[content_api.ProcessorPartTypes]:
+        yield part
+        prober = part.metadata.get("prober")
+        if prober:
+            Prober.log_arrival(part)
+            if self._msg:
+                msg_str = self._msg(part).strip()
+                if msg_str:
+                    logging.info("Latency msg: %s", msg_str)
+            yield content_api.ProcessorPart(
+                "",
+                metadata={"prober": prober},
+                substream_name=self._latency_substream,
+            )
+
+
+class Throttler(processor.Processor):
+    """Throttles the stream by dropping parts if the consumer is too slow.
+
+    This processor maintains an internal buffer and drops the oldest non-prober
+    part when capacity is reached. Parts containing prober information are
+    never dropped; instead, they are prioritized and pushed directly to the
+    output when congestion occurs, ensuring complete latency traces.
+    """
+
+    def __init__(self, tag: str, max_size: int = 2):
+        """Initializes the throttler.
+
+        Args:
+            tag: A label for this throttler used in log messages.
+            max_size: Maximum number of parts to buffer before dropping.
+        """
+        self.tag = tag
+        self.max_size = max_size
+
+    async def call(
+        self, content: processor.ProcessorStream
+    ) -> AsyncIterable[content_api.ProcessorPartTypes]:
+        # input_queue stores parts until max_size is reached.
+        input_queue = asyncio.Queue(maxsize=self.max_size)
+        # output_queue is used to hand off parts to the consumer.
+        output_queue = asyncio.Queue(maxsize=1)
+
+        async def bridge():
+            """Bridges input_queue to output_queue."""
+            while (part := await input_queue.get()) is not None:
+                await output_queue.put(part)
+            await output_queue.put(None)
+
+        async def producer():
+            async for part in content:
+                if input_queue.full():
+                    oldest_part = input_queue.get_nowait()
+                    input_queue.put_nowait(part)
+                    prober = oldest_part.metadata.get("prober")
+                    if prober:
+                        # We block on probers, since we want to see the full trace.
+                        await output_queue.put(oldest_part)
+                    else:
+                        part_type = (
+                            oldest_part.text
+                            if content_api.is_text(oldest_part.mimetype)
+                            and oldest_part.text
+                            else oldest_part.mimetype
+                        )
+                        logging.warning(
+                            "Throttler [%s] queue full, dropping oldest non-prober part: %s",
+                            self.tag,
+                            part_type,
+                        )
+                else:
+                    input_queue.put_nowait(part)
+            await input_queue.put(None)
+
+        bridge_task = processor.create_task(bridge())
+        producer_task = processor.create_task(producer())
+        try:
+            async for part in streams.dequeue(output_queue):
+                yield part
+        finally:
+            producer_task.cancel()
+            bridge_task.cancel()

--- a/genai_processors/dev/latency.py
+++ b/genai_processors/dev/latency.py
@@ -226,7 +226,6 @@ class Throttler(processor.Processor):
             async for part in content:
                 if input_queue.full():
                     oldest_part = input_queue.get_nowait()
-                    input_queue.put_nowait(part)
                     prober = oldest_part.metadata.get("prober")
                     if prober:
                         # We block on probers, since we want to see the full trace.
@@ -243,8 +242,7 @@ class Throttler(processor.Processor):
                             self.tag,
                             part_type,
                         )
-                else:
-                    input_queue.put_nowait(part)
+                input_queue.put_nowait(part)
             await input_queue.put(None)
 
         bridge_task = processor.create_task(bridge())

--- a/genai_processors/tests/latency_test.py
+++ b/genai_processors/tests/latency_test.py
@@ -126,8 +126,8 @@ def test_log_arrival_trace():
 @pytest.mark.asyncio
 async def test_throttler_drop_strategy():
     """Tests that Throttler protects probers and drops the oldest non-prober part."""
-    # max_size=1 in the throttler + 1 in bridge + 1 in hand-off queue, i.e. we can
-    # handle max_size + 3 in flight but then we'll start dropping parts.
+    # max_size=1 in the throttler + 1 in hand-off queue, i.e. we can
+    # handle max_size + 2 in flight but then we'll start dropping parts.
 
     @processor.processor_function
     async def slow_consumer(
@@ -160,7 +160,7 @@ async def test_throttler_drop_strategy():
 
     names = [p.text for p in results if p]
     # See explanation above.
-    assert names == ['p1', 'p2', 'p3', 'p6']
+    assert names == ['p1', 'p2', 'p6']
 
 
 @pytest.mark.asyncio

--- a/genai_processors/tests/latency_test.py
+++ b/genai_processors/tests/latency_test.py
@@ -4,10 +4,10 @@ import time
 import unittest.mock
 
 from collections.abc import AsyncIterable
-from genai_processors.dev import latency
 from genai_processors import content_api
 from genai_processors import processor
 from genai_processors import streams
+from genai_processors.dev import latency
 from unittest.mock import patch
 
 
@@ -15,21 +15,21 @@ from unittest.mock import patch
 async def test_prober_structure():
     """Tests that Prober is scheduled correctly."""
 
-    pipeline = latency.Prober("start", interval_seconds=0.1)
+    pipeline = latency.Prober('start', interval_seconds=0.1)
 
     # Send a few parts to establish a baseline for FPS
-    input_stream = streams.stream_content(["test"] * 11, with_delay_sec=0.02)
+    input_stream = streams.stream_content(['test'] * 11, with_delay_sec=0.02)
     results = await pipeline(input_stream).gather()
 
     for part in results:
         assert part.text == "test"
 
     assert len(results) == 11
-    assert "prober" in results[5].metadata
-    assert "prober" in results[10].metadata
+    assert 'prober' in results[5].metadata
+    assert 'prober' in results[10].metadata
     delta_time = (
-        results[10].metadata["prober"]["markers"][0][1]
-        - results[5].metadata["prober"]["markers"][0][1]
+        results[10].metadata['prober']['markers'][0][1]
+        - results[5].metadata['prober']['markers'][0][1]
     )
     assert delta_time == pytest.approx(0.1, abs=0.01)
 
@@ -37,17 +37,17 @@ async def test_prober_structure():
 @pytest.mark.asyncio
 async def test_probe_checkpoint_trace():
     """Tests that ProbeCheckpoint builds a trace of markers with FPS."""
-    pipeline = latency.ProbeCheckpoint("step1") + latency.ProbeCheckpoint("step2")
+    pipeline = latency.ProbeCheckpoint('step1') + latency.ProbeCheckpoint('step2')
     start_time = 100.0
     # Prober now starts with one marker
     input_stream = [
-        "initial",
+        'initial',
         content_api.ProcessorPart(
-            "test",
+            'test',
             metadata={
-                "prober": {
-                    "start_time": start_time,
-                    "markers": [("start", start_time, 0, 50.0)],
+                'prober': {
+                    'start_time': start_time,
+                    'markers': [('start', start_time, 0, 50.0)],
                 }
             },
         ),
@@ -55,10 +55,10 @@ async def test_probe_checkpoint_trace():
     result = await pipeline(input_stream).gather()
 
     # Check that we have the original marker + the extra 2.
-    markers = result[1].metadata["prober"]["markers"]
+    markers = result[1].metadata['prober']['markers']
     assert len(markers) == 3
-    assert markers[1][0] == "step1"
-    assert markers[2][0] == "step2"
+    assert markers[1][0] == 'step1'
+    assert markers[2][0] == 'step2'
     assert markers[1][3] > 0  # FPS should be present
 
 
@@ -66,49 +66,49 @@ async def test_probe_checkpoint_trace():
 async def test_fps_calculation():
     """Verify that FPS is calculated correctly based on part count."""
     pipeline = (
-        latency.Prober("start", interval_seconds=1.0).to_processor()
-        + latency.ProbeCheckpoint("step").to_processor()
+        latency.Prober('start', interval_seconds=1.0).to_processor()
+        + latency.ProbeCheckpoint('step').to_processor()
     )
     # The first part sets the marker for the prober (start), we collect
     # the prober info after 5 parts, so in total we have 6 parts.
-    input_stream = streams.stream_content(["test"] * 6, with_delay_sec=0.2)
+    input_stream = streams.stream_content(['test'] * 6, with_delay_sec=0.2)
     result = await pipeline(input_stream).gather()
-    fps = result[-1].metadata["prober"]["markers"][0][3]
+    fps = result[-1].metadata['prober']['markers'][0][3]
     assert fps == pytest.approx(5.0, abs=0.1)
 
 
 @pytest.mark.asyncio
 async def test_probe_checkpoint_substream():
     """Tests that ProbeCheckpoint filters by substream_name."""
-    pipeline = latency.ProbeCheckpoint("step", substream_name="server")
+    pipeline = latency.ProbeCheckpoint('step', substream_name='server')
 
     input = [
         content_api.ProcessorPart(
-            "test",
-            metadata={"prober": {"start_time": time.monotonic(), "markers": []}},
+            'test',
+            metadata={'prober': {'start_time': time.monotonic(), 'markers': []}},
         ),
         content_api.ProcessorPart(
-            "test",
-            metadata={"prober": {"start_time": time.monotonic(), "markers": []}},
-            substream_name="server",
+            'test',
+            metadata={'prober': {'start_time': time.monotonic(), 'markers': []}},
+            substream_name='server',
         ),
     ]
     result = await pipeline(input).gather()
-    assert len(result[0].metadata["prober"]["markers"]) == 0
-    assert len(result[1].metadata["prober"]["markers"]) == 1
+    assert len(result[0].metadata['prober']['markers']) == 0
+    assert len(result[1].metadata['prober']['markers']) == 1
 
 
 def test_log_arrival_trace():
     """Tests log_arrival logs FPS and duration."""
-    with unittest.mock.patch("genai_processors.dev.latency.logging.info") as mock_log:
+    with unittest.mock.patch('genai_processors.dev.latency.logging.info') as mock_log:
         part = content_api.ProcessorPart(
-            "test",
+            'test',
             metadata={
-                "prober": {
-                    "start_time": 100.0,
-                    "markers": [
-                        ("step1", 100.01, 0.01, 50.0),
-                        ("step2", 100.03, 0.02, 48.5),
+                'prober': {
+                    'start_time': 100.0,
+                    'markers': [
+                        ('step1', 100.01, 0.01, 50.0),
+                        ('step2', 100.03, 0.02, 48.5),
                     ],
                 }
             },
@@ -117,10 +117,10 @@ def test_log_arrival_trace():
         latency.Prober.log_arrival(part)
 
         mock_log.assert_called()
-        assert "default" == mock_log.call_args[0][1]
+        assert 'default' == mock_log.call_args[0][1]
         trace_arg = mock_log.call_args[0][2]
-        assert "step1 (+10.0ms, 50.0fps)" in trace_arg
-        assert "step2 (+20.0ms, 48.5fps)" in trace_arg
+        assert 'step1 (+10.0ms, 50.0fps)' in trace_arg
+        assert 'step2 (+20.0ms, 48.5fps)' in trace_arg
 
 
 @pytest.mark.asyncio
@@ -130,31 +130,28 @@ async def test_throttler_drop_strategy():
     # handle max_size + 3 in flight but then we'll start dropping parts.
 
     @processor.processor_function
-    async def wait_some(
+    async def slow_consumer(
         content: processor.ProcessorStream,
     ) -> AsyncIterable[content_api.ProcessorPartTypes]:
         async for p in content:
-            await asyncio.sleep(0.5)
+            await asyncio.sleep(0.6)
             yield p
 
-    pipeline = latency.Throttler("test", max_size=1) + wait_some
+    pipeline = latency.Throttler('test', max_size=1) + slow_consumer
     input_stream = streams.stream_content(
         [
-            # This part will be processed immediately, not blocking - arrives at 0sec
-            "p1",
-            # This part will not be dropped, send to output queue. - arrives at 0.1sec
-            # The buffer in the throttler is empty.
-            content_api.ProcessorPart("p2", metadata={"prober": {}}),
-            # This part is buffered. Arrives at 0.2sec
-            "p3",
-            # This part is buffered. Arrives at 0.2 sec
-            # This removes p3 from the buffer: p3 is sent to the output queue,
-            # it is in the bridge and blocked, waiting for the output queue to be
-            # empty.
-            "p4",
-            # This part is buffered. Arrives at 0.4 sec - before p4 is still in the
-            # buffer, p4 is dropped and is replaced by p5.
-            "p5",
+            # processed immediately, not blocking - arrives at 0sec
+            'p1',
+            # goes to output queue - arrives at 0.1sec
+            content_api.ProcessorPart('p2', metadata={'prober': {}}),
+            # goes to output queue - arrives at 0.2sec
+            'p3',
+            # buffered - arrives at 0.3sec
+            'p4',
+            # buffered, drops p4 - arrives at 0.4 sec
+            content_api.ProcessorPart('p5', metadata={'prober': {}}),
+            # buffered, drops p5 because output queue is prober - arrives at 0.5 sec
+            content_api.ProcessorPart('p6', metadata={'prober': {}}),
         ],
         with_delay_sec=0.1,
     )
@@ -163,23 +160,49 @@ async def test_throttler_drop_strategy():
 
     names = [p.text for p in results if p]
     # See explanation above.
-    assert names == ["p1", "p2", "p3", "p5"]
+    assert names == ['p1', 'p2', 'p3', 'p6']
 
 
 @pytest.mark.asyncio
 async def test_probe_log():
     """Tests that ProbeLog logs arrival and yields a latency part."""
-    probe_log = latency.ProbeLog(substream_name="server")
+    probe_log = latency.ProbeLog(substream_name='server')
 
     part = content_api.ProcessorPart(
-        "test",
-        metadata={"prober": {"start_time": 100.0, "markers": [("start", 0, 0, 0)]}},
+        'test',
+        metadata={'prober': {'start_time': 100.0, 'markers': [('start', 0, 0, 0)]}},
     )
-    with patch.object(latency.logging, "log") as mock_info:
+    with patch.object(latency.logging, 'log') as mock_info:
         results = await probe_log(part).gather()
         # We have two parts, the original one and a new one under the
         # latency substream
         assert len(results) == 2
-        assert results[1].substream_name == "latency"
+        assert results[1].substream_name == 'latency'
         # first arg of log info is about latency
-        assert "Latency Trace" in mock_info.call_args_list[0][0][1]
+        assert 'Latency Trace' in mock_info.call_args_list[0][0][1]
+
+
+@pytest.mark.asyncio
+async def test_throttler_warning_log():
+    """Tests that Throttler logs a warning when dropping non-prober parts."""
+
+    @processor.processor_function
+    async def slow_consumer(
+        content: processor.ProcessorStream,
+    ) -> AsyncIterable[content_api.ProcessorPartTypes]:
+        async for p in content:
+            await asyncio.sleep(0.5)
+            yield p
+
+    throttler = latency.Throttler('test_log', max_size=1, log_interval_sec=0.1)
+    pipeline = throttler + slow_consumer
+    input_stream = streams.stream_content(
+        [f'p{i}' for i in range(10)], with_delay_sec=0.025
+    )
+
+    with patch.object(latency.logging, 'warning') as mock_warning:
+        await pipeline(input_stream).gather()
+        mock_warning.assert_called()
+        assert 'Throttler' in mock_warning.call_args[0][0]
+        # 4 = 3 drops every 0.03 secs + 1 drop after 0.1 secs
+        assert 4 == mock_warning.call_args[0][2]

--- a/genai_processors/tests/latency_test.py
+++ b/genai_processors/tests/latency_test.py
@@ -1,0 +1,180 @@
+import asyncio
+import pytest
+import time
+import unittest.mock
+
+from collections.abc import AsyncIterable
+from genai_processors.dev import latency
+from genai_processors import content_api
+from genai_processors import processor
+from genai_processors import streams
+from unittest.mock import patch
+
+
+@pytest.mark.asyncio
+async def test_prober_structure():
+    """Tests that Prober is scheduled correctly."""
+
+    pipeline = latency.Prober("start", interval_seconds=0.1)
+
+    # Send a few parts to establish a baseline for FPS
+    input_stream = streams.stream_content(["test"] * 6, with_delay_sec=0.02)
+    results = await pipeline(input_stream).gather()
+
+    for part in results:
+        assert part.text == "test"
+
+    assert len(results) == 6
+    assert "prober" in results[0].metadata
+    assert "prober" in results[5].metadata
+    delta_time = (
+        results[5].metadata["prober"]["markers"][0][1]
+        - results[0].metadata["prober"]["markers"][0][1]
+    )
+    assert delta_time == pytest.approx(0.1, abs=0.01)
+
+
+@pytest.mark.asyncio
+async def test_probe_checkpoint_trace():
+    """Tests that ProbeCheckpoint builds a trace of markers with FPS."""
+    pipeline = latency.ProbeCheckpoint("step1") + latency.ProbeCheckpoint("step2")
+    start_time = 100.0
+    # Prober now starts with one marker
+    metadata = {
+        "prober": {
+            "start_time": start_time,
+            "markers": [("start", start_time, 0, 50.0)],
+        }
+    }
+    input_stream = [content_api.ProcessorPart("test", metadata=metadata)]
+    result = await pipeline(input_stream).gather()
+
+    # Check that we have the original marker + the extra 2.
+    markers = result[0].metadata["prober"]["markers"]
+    assert len(markers) == 3
+    assert markers[1][0] == "step1"
+    assert markers[2][0] == "step2"
+    assert markers[1][3] > 0  # FPS should be present
+
+
+@pytest.mark.asyncio
+async def test_fps_calculation():
+    """Verify that FPS is calculated correctly based on part count."""
+    pipeline = (
+        latency.Prober("start", interval_seconds=1.0).to_processor()
+        + latency.ProbeCheckpoint("step").to_processor()
+    )
+    # The first part sets the marker for the prober (start), we collect
+    # the prober info after 5 parts, so in total we have 6 parts.
+    input_stream = streams.stream_content(["test"] * 6, with_delay_sec=0.2)
+    result = await pipeline(input_stream).gather()
+    fps = result[-1].metadata["prober"]["markers"][0][3]
+    assert fps == pytest.approx(5.0, abs=0.1)
+
+
+@pytest.mark.asyncio
+async def test_probe_checkpoint_substream():
+    """Tests that ProbeCheckpoint filters by substream_name."""
+    pipeline = latency.ProbeCheckpoint("step", substream_name="server")
+
+    input = [
+        content_api.ProcessorPart(
+            "test",
+            metadata={"prober": {"start_time": time.monotonic(), "markers": []}},
+        ),
+        content_api.ProcessorPart(
+            "test",
+            metadata={"prober": {"start_time": time.monotonic(), "markers": []}},
+            substream_name="server",
+        ),
+    ]
+    result = await pipeline(input).gather()
+    assert len(result[0].metadata["prober"]["markers"]) == 0
+    assert len(result[1].metadata["prober"]["markers"]) == 1
+
+
+def test_log_arrival_trace():
+    """Tests log_arrival logs FPS and duration."""
+    with unittest.mock.patch("genai_processors.dev.latency.logging.info") as mock_log:
+        part = content_api.ProcessorPart(
+            "test",
+            metadata={
+                "prober": {
+                    "start_time": 100.0,
+                    "markers": [
+                        ("step1", 100.01, 0.01, 50.0),
+                        ("step2", 100.03, 0.02, 48.5),
+                    ],
+                }
+            },
+        )
+
+        latency.Prober.log_arrival(part)
+
+        mock_log.assert_called()
+        assert "default" == mock_log.call_args[0][1]
+        trace_arg = mock_log.call_args[0][2]
+        assert "step1 (+10.0ms, 50.0fps)" in trace_arg
+        assert "step2 (+20.0ms, 48.5fps)" in trace_arg
+
+
+@pytest.mark.asyncio
+async def test_throttler_drop_strategy():
+    """Tests that Throttler protects probers and drops the oldest non-prober part."""
+    # max_size=1 in the throttler + 1 in bridge + 1 in hand-off queue, i.e. we can
+    # handle max_size + 3 in flight but then we'll start dropping parts.
+
+    @processor.processor_function
+    async def wait_some(
+        content: processor.ProcessorStream,
+    ) -> AsyncIterable[content_api.ProcessorPartTypes]:
+        async for p in content:
+            await asyncio.sleep(0.5)
+            yield p
+
+    pipeline = latency.Throttler("test", max_size=1) + wait_some
+    input_stream = streams.stream_content(
+        [
+            # This part will be processed immediately, not blocking - arrives at 0sec
+            "p1",
+            # This part will not be dropped, send to output queue. - arrives at 0.1sec
+            # The buffer in the throttler is empty.
+            content_api.ProcessorPart("p2", metadata={"prober": {}}),
+            # This part is buffered. Arrives at 0.2sec
+            "p3",
+            # This part is buffered. Arrives at 0.2 sec
+            # This removes p3 from the buffer: p3 is sent to the output queue,
+            # it is in the bridge and blocked, waiting for the output queue to be
+            # empty.
+            "p4",
+            # This part is buffered. Arrives at 0.4 sec - before p4 is still in the
+            # buffer, p4 is dropped and is replaced by p5.
+            "p5",
+        ],
+        with_delay_sec=0.1,
+    )
+
+    results = await pipeline(input_stream).gather()
+
+    names = [p.text for p in results if p]
+    # See explanation above.
+    assert names == ["p1", "p2", "p3", "p5"]
+
+
+@pytest.mark.asyncio
+async def test_probe_log():
+    """Tests that ProbeLog logs arrival and yields a latency part."""
+    probe_log = latency.ProbeLog(substream_name="server")
+
+    part = content_api.ProcessorPart(
+        "test",
+        metadata={"prober": {"start_time": 100.0, "markers": [("start", 0, 0, 0)]}},
+    )
+    with patch.object(latency.logging, "log") as mock_info:
+        results = await probe_log(part).gather()
+        # We have two parts, the original one and a new one under the
+        # latency substream
+        assert len(results) == 2
+        assert results[1].substream_name == "latency"
+        # first arg of log info is about latency
+        assert "Latency Trace" in mock_info.call_args_list[0][0][1]

--- a/genai_processors/tests/latency_test.py
+++ b/genai_processors/tests/latency_test.py
@@ -18,18 +18,18 @@ async def test_prober_structure():
     pipeline = latency.Prober("start", interval_seconds=0.1)
 
     # Send a few parts to establish a baseline for FPS
-    input_stream = streams.stream_content(["test"] * 6, with_delay_sec=0.02)
+    input_stream = streams.stream_content(["test"] * 11, with_delay_sec=0.02)
     results = await pipeline(input_stream).gather()
 
     for part in results:
         assert part.text == "test"
 
-    assert len(results) == 6
-    assert "prober" in results[0].metadata
+    assert len(results) == 11
     assert "prober" in results[5].metadata
+    assert "prober" in results[10].metadata
     delta_time = (
-        results[5].metadata["prober"]["markers"][0][1]
-        - results[0].metadata["prober"]["markers"][0][1]
+        results[10].metadata["prober"]["markers"][0][1]
+        - results[5].metadata["prober"]["markers"][0][1]
     )
     assert delta_time == pytest.approx(0.1, abs=0.01)
 
@@ -40,17 +40,22 @@ async def test_probe_checkpoint_trace():
     pipeline = latency.ProbeCheckpoint("step1") + latency.ProbeCheckpoint("step2")
     start_time = 100.0
     # Prober now starts with one marker
-    metadata = {
-        "prober": {
-            "start_time": start_time,
-            "markers": [("start", start_time, 0, 50.0)],
-        }
-    }
-    input_stream = [content_api.ProcessorPart("test", metadata=metadata)]
+    input_stream = [
+        "initial",
+        content_api.ProcessorPart(
+            "test",
+            metadata={
+                "prober": {
+                    "start_time": start_time,
+                    "markers": [("start", start_time, 0, 50.0)],
+                }
+            },
+        ),
+    ]
     result = await pipeline(input_stream).gather()
 
     # Check that we have the original marker + the extra 2.
-    markers = result[0].metadata["prober"]["markers"]
+    markers = result[1].metadata["prober"]["markers"]
     assert len(markers) == 3
     assert markers[1][0] == "step1"
     assert markers[2][0] == "step2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ dev = [
     "pyink",
     "pylint>=2.6.0",
     "pytest",
+    "pytest-asyncio",
     "pytest-xdist",
     "torch",
     "transformers",


### PR DESCRIPTION
The Prober and ProbeCheckpoint processors allow to measure the latency over specific parts of a pipeline. This is lighter than the full trace and can be kept in deployment to check every xx seconds that the pipeline is healthy.