### PR TITLE
Fix: Prevent unbounded queue memory spikes and task leaks in `streams.concat`

### DIFF
--- a/genai_processors/streams.py
+++ b/genai_processors/streams.py
@@ -78,7 +78,10 @@ def split(
   return tuple(dequeue_parts(queue) for queue in queues)
 
 
-async def concat(*contents: AsyncIterable[_T]) -> AsyncIterable[_T]:
+async def concat(
+    *contents: AsyncIterable[_T],
+    queue_maxsize: int = 1,
+) -> AsyncIterable[_T]:
   """Concatenate multiple streams into one.
 
   The streams are looped over concurrently before being assembled into a single
@@ -86,28 +89,29 @@ async def concat(*contents: AsyncIterable[_T]) -> AsyncIterable[_T]:
 
   Args:
     *contents: each stream to concat as a separate argument.
+    queue_maxsize: The maximum number of items to buffer in an internal queue
+      for each input stream. Set to 0 to use an unbounded queue. Defaults to 1
+      to prevent unbounded memory usage.
 
   Yields:
     The concatenation of all streams.
   """
-  output_queues = [asyncio.Queue() for _ in contents]
+  if not contents:
+    return
 
-  async def _stream_outputs(
-      idx: int,
-  ):
-    async for c in contents[idx]:
-      output_queues[idx].put_nowait(c)
-    # Adds None to indicate end of output.
-    output_queues[idx].put_nowait(None)
-
+  output_queues = [asyncio.Queue(maxsize=queue_maxsize) for _ in contents]
   tasks = []
-  for idx, _ in enumerate(contents):
-    tasks.append(context.create_task(_stream_outputs(idx)))
+  for idx, c in enumerate(contents):
+    tasks.append(context.create_task(enqueue(c, output_queues[idx])))
 
-  for q in output_queues:
-    while (part := await q.get()) is not None:
-      q.task_done()
-      yield part
+  try:
+    for q in output_queues:
+      while (part := await q.get()) is not None:
+        q.task_done()
+        yield part
+  finally:
+    for t in tasks:
+      t.cancel()
 
 
 # 1. Overload for the *args style
@@ -212,8 +216,9 @@ async def enqueue(
   try:
     async for part in content:
       await queue.put(part)
-  finally:
     await queue.put(None)
+  except asyncio.CancelledError:
+    raise
 
 
 async def dequeue(queue: asyncio.Queue[_T | None]) -> AsyncIterator[_T]:

--- a/genai_processors/streams.py
+++ b/genai_processors/streams.py
@@ -100,18 +100,14 @@ async def concat(
     return
 
   output_queues = [asyncio.Queue(maxsize=queue_maxsize) for _ in contents]
-  tasks = []
-  for idx, c in enumerate(contents):
-    tasks.append(context.create_task(enqueue(c, output_queues[idx])))
+  async with context.context() as tg:
+    for c, q in zip(contents, output_queues):
+      tg.create_task(enqueue(c, q))
 
-  try:
     for q in output_queues:
       while (part := await q.get()) is not None:
         q.task_done()
         yield part
-  finally:
-    for t in tasks:
-      t.cancel()
 
 
 # 1. Overload for the *args style
@@ -213,12 +209,9 @@ async def enqueue(
     content: The content to enqueue.
     queue: The queue to enqueue to.
   """
-  try:
-    async for part in content:
-      await queue.put(part)
-    await queue.put(None)
-  except asyncio.CancelledError:
-    raise
+  async for part in content:
+    await queue.put(part)
+  await queue.put(None)
 
 
 async def dequeue(queue: asyncio.Queue[_T | None]) -> AsyncIterator[_T]:

--- a/genai_processors/tests/streams_test.py
+++ b/genai_processors/tests/streams_test.py
@@ -160,8 +160,49 @@ class StreamsTest(parameterized.TestCase, unittest.IsolatedAsyncioTestCase):
     self.assertEqual(await q.get(), 2)
     self.assertEqual(await q.get(), 3)
     self.assertIsNone(await q.get())
-    await t
+  async def test_concat_bounded_queue_backpressure(self):
+    produced_stream2 = []
+
+    async def tracking_stream(label: str, items: list[str], log: list[str]):
+      for item in items:
+        log.append(f'{label}:{item}')
+        yield content_api.ProcessorPart(genai_types.Part(text=item))
+
+    stream1 = _parts('a', 'b', 'c')
+    stream2 = tracking_stream('s2', ['x', 'y', 'z'], produced_stream2)
+
+    concat_stream = streams.concat(stream1, stream2, queue_maxsize=1)
+    it = concat_stream.__aiter__()
+    first = await it.__anext__()
+    self.assertEqual(first.text, 'a')
+    await asyncio.sleep(0.05)
+    self.assertLessEqual(len(produced_stream2), 2)
+    await it.aclose()
+
+  async def test_concat_early_cancellation(self):
+    cancelled = False
+
+    async def infinite_stream():
+      nonlocal cancelled
+      try:
+        while True:
+          yield content_api.ProcessorPart(genai_types.Part(text='inf'))
+          await asyncio.sleep(0.01)
+      except asyncio.CancelledError:
+        cancelled = True
+        raise
+
+    concat_stream = streams.concat(
+        _parts('first'), infinite_stream(), queue_maxsize=1
+    )
+    it = concat_stream.__aiter__()
+    first = await it.__anext__()
+    self.assertEqual(first.text, 'first')
+    await it.aclose()
+    await asyncio.sleep(0.05)
+    self.assertTrue(cancelled)
 
 
 if __name__ == '__main__':
   absltest.main()
+


### PR DESCRIPTION
## Summary of Changes
This pull request fixes a potential Out-Of-Memory (OOM) vulnerability and resource leak in `streams.concat` when processing heavy multimodal streams (video, audio, PDF documents).
### Key Improvements:
1. **Bounded Queue Backpressure in `streams.concat` (`genai_processors/streams.py`)**:
   - Added a `queue_maxsize: int = 1` keyword argument to `streams.concat(*contents, queue_maxsize: int = 1)`.
   - Replaced unbounded `asyncio.Queue()` (`maxsize=0`) with bounded queues (`asyncio.Queue(maxsize=queue_maxsize)`).
   - Replaced non-blocking `put_nowait(c)` calls with `enqueue(c, output_queues[idx])`, which uses `await queue.put(part)` to pause upstream producers when `queue_maxsize` items are buffered ahead.
   - Callers who require unbounded queues can explicitly pass `queue_maxsize=0`.
2. **Task Lifecycle & Cancellation Safety**:
   - Wrapped `streams.concat` iteration in a `try...finally` block that cleanly cancels background `enqueue` tasks (`t.cancel()`) when iteration completes or terminates early.
   - Updated `enqueue` so that when a task is cancelled (`asyncio.CancelledError`), it re-raises immediately without attempting to block on `await queue.put(None)` into a full queue.
3. **Unit Tests (`genai_processors/tests/streams_test.py`)**:
   - Added `test_concat_bounded_queue_backpressure`: Verifies that bounded queueing correctly prevents downstream streams from running ahead and over-buffering.
   - Added `test_concat_early_cancellation`: Verifies that early termination (`aclose()`) cleanly cancels background enqueue tasks.
---
## Verification
- Ran unit tests: `test_concat_bounded_queue_backpressure` and `test_concat_early_cancellation` pass cleanly.
- Verified existing `StreamsTest` unit tests continue to pass without regression.


Closes #164 