### PR TITLE
fix(streams): prevent unbounded queue memory spikes and task leaks in streams.concat

### DIFF
--- a/genai_processors/streams.py
+++ b/genai_processors/streams.py
@@ -78,7 +78,10 @@ def split(
   return tuple(dequeue_parts(queue) for queue in queues)
 
 
-async def concat(*contents: AsyncIterable[_T]) -> AsyncIterable[_T]:
+async def concat(
+    *contents: AsyncIterable[_T],
+    queue_maxsize: int = 1,
+) -> AsyncIterable[_T]:
   """Concatenate multiple streams into one.
 
   The streams are looped over concurrently before being assembled into a single
@@ -86,28 +89,38 @@ async def concat(*contents: AsyncIterable[_T]) -> AsyncIterable[_T]:
 
   Args:
     *contents: each stream to concat as a separate argument.
+    queue_maxsize: The maximum number of items to buffer in an internal queue
+      for each input stream. Set to 0 to use an unbounded queue.
 
   Yields:
     The concatenation of all streams.
   """
-  output_queues = [asyncio.Queue() for _ in contents]
+  output_queues = [asyncio.Queue(maxsize=queue_maxsize) for _ in contents]
 
-  async def _stream_outputs(
-      idx: int,
-  ):
-    async for c in contents[idx]:
-      output_queues[idx].put_nowait(c)
-    # Adds None to indicate end of output.
-    output_queues[idx].put_nowait(None)
+  async def _stream_outputs(idx: int):
+    try:
+      async for c in contents[idx]:
+        await output_queues[idx].put(c)
+      await output_queues[idx].put(None)
+    except asyncio.CancelledError:
+      raise
 
   tasks = []
-  for idx, _ in enumerate(contents):
-    tasks.append(context.create_task(_stream_outputs(idx)))
+  try:
+    for idx, _ in enumerate(contents):
+      tasks.append(context.create_task(_stream_outputs(idx)))
 
-  for q in output_queues:
-    while (part := await q.get()) is not None:
+    for q in output_queues:
+      while (part := await q.get()) is not None:
+        q.task_done()
+        yield part
       q.task_done()
-      yield part
+  finally:
+    for t in tasks:
+      if not t.done():
+        t.cancel()
+    if tasks:
+      await asyncio.gather(*tasks, return_exceptions=True)
 
 
 # 1. Overload for the *args style
@@ -212,8 +225,9 @@ async def enqueue(
   try:
     async for part in content:
       await queue.put(part)
-  finally:
     await queue.put(None)
+  except asyncio.CancelledError:
+    raise
 
 
 async def dequeue(queue: asyncio.Queue[_T | None]) -> AsyncIterator[_T]:

--- a/genai_processors/tests/streams_test.py
+++ b/genai_processors/tests/streams_test.py
@@ -162,6 +162,28 @@ class StreamsTest(parameterized.TestCase, unittest.IsolatedAsyncioTestCase):
     self.assertIsNone(await q.get())
     await t
 
+  async def test_concat_backpressure_and_cancellation(self):
+    task_started = asyncio.Event()
+    task_cancelled = asyncio.Event()
+
+    async def producer():
+      task_started.set()
+      try:
+        for val in [1, 2, 3]:
+          yield val
+          await asyncio.sleep(0.01)
+      except asyncio.CancelledError:
+        task_cancelled.set()
+        raise
+
+    concat_stream = streams.concat(producer(), queue_maxsize=1)
+    async for item in concat_stream:
+      self.assertEqual(item, 1)
+      break
+
+    await asyncio.sleep(0.05)
+    self.assertTrue(task_cancelled.is_set())
+
 
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
This PR resolves #164.

### Description
In `genai_processors/streams.py`, `streams.concat(*contents)` is used to concatenate multiple asynchronous streams. Previously, it initialized internal `asyncio.Queue()` instances with unbounded size (`maxsize=0`) and spawned concurrent background tasks calling `put_nowait(c)`. This caused all subsequent streams to buffer entirely in RAM while the consumer was still reading the first stream, leading to memory spikes and potential OOM issues.

Furthermore:
1. If the consumer stopped iterating early (due to a `break` or exception), the background tasks remained running, resulting in task/resource leaks.
2. If an `enqueue` task was cancelled while blocked on a queue put, the `finally: await queue.put(None)` block blocked indefinitely on a full queue, causing the task to hang.

This PR:
1. Enforces bounded buffer capacities (`queue_maxsize: int = 1` by default) in `streams.concat` to provide backpressure.
2. Wraps the queue consumption loop in a `try...finally` block to cancel and clean up background tasks if iteration finishes early or errors.
3. Fixes `enqueue` to prevent hanging on cancellation by avoiding blocking queue operations in the `CancelledError` path.
4. Adds a unit test `test_concat_backpressure_and_cancellation` to `genai_processors/tests/streams_test.py` to verify this behavior.
